### PR TITLE
Speed up Rust code

### DIFF
--- a/Shaking the Rust Off Python/Cargo.toml
+++ b/Shaking the Rust Off Python/Cargo.toml
@@ -18,3 +18,6 @@ opt-level = 3
 
 [profile.release]
 debug = 0
+lto = "fat"
+codegen-units = 1
+panic = "abort"

--- a/Shaking the Rust Off Python/count_kmers_rust_multithread_fx_hashmap.py
+++ b/Shaking the Rust Off Python/count_kmers_rust_multithread_fx_hashmap.py
@@ -53,7 +53,7 @@ def count_kmers_rust_multithread_fx_hashmap(fasta_file: str,
 
     # Step 2. Run
     start_time_2 = time.time()
-    results = scripts.count_kmers_multithread_fx_hashmap(sequences, k, num_processes)
+    results = scripts.count_kmers_multithread_fx_hashmap(sequences, k)
     end_time_2 = time.time()
 
     # Step 3. Merge dictionaries into one

--- a/Shaking the Rust Off Python/count_kmers_rust_multithread_stl_hashmap.py
+++ b/Shaking the Rust Off Python/count_kmers_rust_multithread_stl_hashmap.py
@@ -53,7 +53,7 @@ def count_kmers_rust_multithread_stl_hashmap(fasta_file: str,
 
     # Step 2. Run
     start_time_2 = time.time()
-    results = scripts.count_kmers_multithread_stl_hashmap(sequences, k, num_processes)
+    results = scripts.count_kmers_multithread_stl_hashmap(sequences, k)
     end_time_2 = time.time()
 
     # Step 3. Merge dictionaries into one

--- a/Shaking the Rust Off Python/src/lib.rs
+++ b/Shaking the Rust Off Python/src/lib.rs
@@ -1,128 +1,98 @@
 use pyo3::prelude::*;
 use rayon::prelude::*;
-use std::collections::HashMap;
 use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 #[pyfunction]
-fn count_kmers_multithread_stl_hashmap(sequences: Vec<String>, k: usize, num_threads: usize) -> Py<PyAny> {
-    let pool = rayon::ThreadPoolBuilder::new()
-    .num_threads(num_threads)
-    .build()
-    .unwrap();
-    let (tx, rx) = std::sync::mpsc::channel();
-    for seq in &sequences {
-        let tx = tx.clone();
-        let seq = seq.to_owned();
-        pool.spawn(move || {
-            let mut hm : HashMap<String, i32> = HashMap::new();
-            let end = seq.chars().count() - k + 1;
-            for i in 0..end {
-                *hm.entry(seq[i..i+k].to_owned()).or_insert(0) += 1;
+fn count_kmers_multithread_stl_hashmap(sequences: Vec<String>, k: usize) -> Py<PyAny> {
+    let hm = sequences
+        .par_iter()
+        .map(|sequence| {
+            let mut map: HashMap<_, u32> = HashMap::default();
+            for i in 0..sequence.len() - k + 1 {
+                *map.entry(&sequence[i..i + k]).or_insert(0) += 1;
             }
-            tx.send(hm).unwrap();
-        });
-    }
+            map
+        })
+        .reduce(
+            || HashMap::default(),
+            |mut acc, x| {
+                for (k, v) in x {
+                    *acc.entry(k).or_insert(0) += v;
+                }
+                acc
+            },
+        );
 
-    drop(tx); // close all senders
-    let results: Vec<HashMap<String, i32>> = rx.into_iter().collect();
-
-    // Merge HashMaps
-    let mut hm : HashMap<&str, i32> = HashMap::new();
-    for curr_hm in &results {
-        for (key, value) in curr_hm.into_iter() {
-            *hm.entry(&key).or_insert(0) += value;
-        }
-    }
-
-    return Python::with_gil(|py| {
-        hm.to_object(py)
-    });
+    Python::with_gil(|py| hm.to_object(py))
 }
 
 #[pyfunction]
-fn count_kmers_multithread_fx_hashmap(sequences: Vec<String>, k: usize, num_threads: usize) -> Py<PyAny> {
-    let pool = rayon::ThreadPoolBuilder::new()
-    .num_threads(num_threads)
-    .build()
-    .unwrap();
-    let (tx, rx) = std::sync::mpsc::channel();
-    for seq in &sequences {
-        let tx = tx.clone();
-        let seq = seq.to_owned();
-        pool.spawn(move || {
-            let mut hm : FxHashMap<String, i32> = FxHashMap::default();
-            let end = seq.chars().count() - k + 1;
-            for i in 0..end {
-                *hm.entry(seq[i..i+k].to_owned()).or_insert(0) += 1;
+fn count_kmers_multithread_fx_hashmap(sequences: Vec<String>, k: usize) -> Py<PyAny> {
+    let hm = sequences
+        .par_iter()
+        .map(|sequence| {
+            let mut map: FxHashMap<_, u32> = FxHashMap::default();
+            // Use built-in windows iterator to give us k-mers - less math!
+            for window in sequence.as_bytes().windows(k) {
+                // SAFETY: window is valid UTF-8, since we got it from sequence.as_bytes()!
+                let s = unsafe { std::str::from_utf8_unchecked(window) };
+                *map.entry(s).or_insert(0) += 1;
             }
-            tx.send(hm).unwrap();
-        });
-    }
+            map
+        })
+        .reduce(
+            || FxHashMap::default(),
+            |mut acc, x| {
+                for (k, v) in x {
+                    *acc.entry(k).or_insert(0) += v;
+                }
+                acc
+            },
+        );
 
-    drop(tx); // close all senders
-    let results: Vec<FxHashMap<String, i32>> = rx.into_iter().collect();
-
-    // Merge HashMaps
-    let mut hm : FxHashMap<&str, i32> = FxHashMap::default();
-    for curr_hm in &results {
-        for (key, value) in curr_hm.into_iter() {
-            *hm.entry(&key).or_insert(0) += value;
-        }
-    }
-
-    return Python::with_gil(|py| {
-        hm.to_object(py)
-    });
+    Python::with_gil(|py| hm.to_object(py))
 }
 
 #[pyfunction]
 fn count_kmers_stl_hashmap(sequence: String, k: usize) -> Py<PyAny> {
-    let mut hm : HashMap<String, i32> = HashMap::new();
+    let mut hm: HashMap<String, i32> = HashMap::new();
     let end = sequence.chars().count() - k + 1;
     for j in 0..end {
-        *hm.entry(sequence[j..j+k].to_string()).or_insert(0) += 1;
+        *hm.entry(sequence[j..j + k].to_string()).or_insert(0) += 1;
     }
-    return Python::with_gil(|py| {
-        hm.to_object(py)
-    });
+    return Python::with_gil(|py| hm.to_object(py));
 }
 
 #[pyfunction]
 fn count_kmers_stl_hashmap_pointer(sequence: String, k: usize) -> Py<PyAny> {
-    let mut hm : HashMap<&str, i32> = HashMap::new();
+    let mut hm: HashMap<&str, i32> = HashMap::new();
     let end = sequence.chars().count() - k + 1;
     for j in 0..end {
-        *hm.entry(&sequence[j..j+k]).or_insert(0) += 1;
+        *hm.entry(&sequence[j..j + k]).or_insert(0) += 1;
     }
-    return Python::with_gil(|py| {
-        hm.to_object(py)
-    });
+    return Python::with_gil(|py| hm.to_object(py));
 }
 
 #[pyfunction]
 fn count_kmers_fx_hashmap(sequence: String, k: usize) -> Py<PyAny> {
-    let mut hm : FxHashMap<String, i32> = FxHashMap::default();
+    let mut hm: FxHashMap<String, i32> = FxHashMap::default();
     let end = sequence.chars().count() - k + 1;
     for j in 0..end {
-        *hm.entry(sequence[j..j+k].to_string()).or_insert(0) += 1;
+        *hm.entry(sequence[j..j + k].to_string()).or_insert(0) += 1;
     }
-    return Python::with_gil(|py| {
-        hm.to_object(py)
-    });
+    return Python::with_gil(|py| hm.to_object(py));
 }
 
 #[pyfunction]
 fn count_kmers_fx_hashmap_pointer(sequence: String, k: usize) -> Py<PyAny> {
-    let mut hm : FxHashMap<&str, i32> = FxHashMap::default();
+    let mut hm: FxHashMap<&str, i32> = FxHashMap::default();
     let end = sequence.chars().count() - k + 1;
     for j in 0..end {
-        *hm.entry(&sequence[j..j+k]).or_insert(0) += 1;
+        *hm.entry(&sequence[j..j + k]).or_insert(0) += 1;
     }
-    return Python::with_gil(|py| {
-        hm.to_object(py)
-    });
+    return Python::with_gil(|py| hm.to_object(py));
 }
-
 
 #[pymodule]
 fn scripts(_py: Python, m: &PyModule) -> PyResult<()> {

--- a/Shaking the Rust Off Python/src/lib.rs
+++ b/Shaking the Rust Off Python/src/lib.rs
@@ -33,11 +33,8 @@ fn count_kmers_multithread_fx_hashmap(sequences: Vec<String>, k: usize) -> Py<Py
         .par_iter()
         .map(|sequence| {
             let mut map: FxHashMap<_, u32> = FxHashMap::default();
-            // Use built-in windows iterator to give us k-mers - less math!
-            for window in sequence.as_bytes().windows(k) {
-                // SAFETY: window is valid UTF-8, since we got it from sequence.as_bytes()!
-                let s = unsafe { std::str::from_utf8_unchecked(window) };
-                *map.entry(s).or_insert(0) += 1;
+            for i in 0..sequence.len() - k + 1 {
+                *map.entry(&sequence[i..i + k]).or_insert(0) += 1;
             }
             map
         })


### PR DESCRIPTION
Hi,
I've submitted a PR that speeds up the multithreaded Rust code ~3x, as I tweeted about 😄 

- Use Rayon parallel iterators
- Remove unnecessary String clones, using &str slices instead
- Add performance flags to Cargo.toml under [release] section

Couple other general notes:

* Use `maturin dev --release`, otherwise you will be measuring debug build runtimes

* You mention using "pointers" in the blog - there are no pointers anywhere in the code! Rust has the concept of references (and slices) in addition to pointers. 

Pointers in Rust require the use of unsafe code blocks. References have lifetimes that are checked by the borrow checker, ensuring that they are never dangling. This a `&str` slice (or reference) to a String, not a pointer! 
```rs
&sequence[i..i+k]
```

Using `to_owned()` causes an additional memory allocation

* "STL" - This is a C++ term (Standard Template Library), rust just calls it the standard library or `std`